### PR TITLE
Updates to produce log files with date codes; resolved STR# 4470 for …

### DIFF
--- a/tests/README.txt
+++ b/tests/README.txt
@@ -3,7 +3,8 @@ README.txt - 2015-10-09
 
 INTRODUCTION
 
-    This directory contains the IPP Everywhere Printer Self-Certification tools.
+    This directory contains the IPP Everywhere Printer Self-Certification
+    tools.
 
     In addition to the files in this directory, you must also download and
     extract one or more PWG Raster Format file archives from:
@@ -37,6 +38,69 @@ CONTENTS
       LICENSE.txt         CUPS software license
       man-*.html          HTML documentation for the tools
       README.txt          This README file
+
+
+
+RUNNING THE SUITE
+
+  Linux and OS X
+
+    In the top level directory of the distribution, you can execute the
+    following command to find your target printer's DNS-SD Instance Name:
+
+      ./ipptool -s
+
+    If your printer implements the "_print" DNS-SD subtype for the "_ipp._tcp"
+    service type that is required by IPP Everywhere, you can filter the
+    results using this command, if you have many printers:
+
+      ./ipptool "_print._ipp._tcp" -s
+
+    Once you have acquired the target printer's DNS-SD Instance Name, you can
+    execute the following commands to run the 3 sets of tests ("Example Test Printer"
+    is the example DNS-SD Instance Name in the examples below):
+
+      ./runtests.sh bonjour-tests.sh "Example Test Printer"
+      ./runtests.sh ipp-tests.sh "Example Test Printer"
+      ./runtests.sh document-tests.sh "Example Test Printer"
+
+    The corresponding PWG Raster sample files (see link in the introduction) MUST
+    be placed in a subdirectory of the "tests" directory. For example:
+
+      cd tests
+      curl http://ftp.pwg.org/pub/pwg/ipp/examples/pwg-raster-samples-300dpi-20150616.zip >temp.zip
+      unzip temp.zip
+      rm temp.zip
+      cd ..
+
+  Windows
+    You'll need to manually copy the DLL and EXE files from the "vcnet" directory
+    to the "tests" directory.
+
+    In the top level directory of the distribution, you can execute the
+    following command to find your target printer's DNS-SD Instance Name:
+
+      .\ipptool -s
+
+    If your printer implements the "_print" DNS-SD subtype for the "_ipp._tcp"
+    service type that is required by IPP Everywhere, you can filter the
+    results using this command, if you have many printers:
+
+      .\ipptool "_print._ipp._tcp" -s
+
+    Once you have acquired the target printer's DNS-SD Instance Name, you can
+    execute the following commands to run the 3 sets of tests ("Example Test Printer"
+    is the example DNS-SD Instance Name in the examples below):
+
+      cd tests
+      .\bonjour-tests.bat "Example Test Printer"
+      .\ipp-tests.bat "Example Test Printer"
+      .\document-tests.bat "Example Test Printer"
+
+    The corresponding PWG Raster sample files (see link in the introduction) MUST
+    be placed in a subdirectory of the "tests" directory. After downloading the
+    files just extract them using Windows Explorer.
+
 
 
 GETTING SUPPORT AND OTHER RESOURCES

--- a/tests/README.txt
+++ b/tests/README.txt
@@ -48,13 +48,13 @@ RUNNING THE SUITE
     In the top level directory of the distribution, you can execute the
     following command to find your target printer's DNS-SD Instance Name:
 
-      ./ipptool -s
+      ./ippfind -s
 
     If your printer implements the "_print" DNS-SD subtype for the "_ipp._tcp"
     service type that is required by IPP Everywhere, you can filter the
     results using this command, if you have many printers:
 
-      ./ipptool "_print._ipp._tcp" -s
+      ./ippfind "_print._ipp._tcp" -s
 
     Once you have acquired the target printer's DNS-SD Instance Name, you can
     execute the following commands to run the 3 sets of tests ("Example Test Printer"
@@ -80,13 +80,13 @@ RUNNING THE SUITE
     In the top level directory of the distribution, you can execute the
     following command to find your target printer's DNS-SD Instance Name:
 
-      .\ipptool -s
+      .\ippfind -s
 
     If your printer implements the "_print" DNS-SD subtype for the "_ipp._tcp"
     service type that is required by IPP Everywhere, you can filter the
     results using this command, if you have many printers:
 
-      .\ipptool "_print._ipp._tcp" -s
+      .\ippfind "_print._ipp._tcp" -s
 
     Once you have acquired the target printer's DNS-SD Instance Name, you can
     execute the following commands to run the 3 sets of tests ("Example Test Printer"

--- a/tests/bonjour-tests.sh
+++ b/tests/bonjour-tests.sh
@@ -340,6 +340,9 @@ echo "Summary: $total tests, $pass passed, $fail failed, $skip skipped"
 echo "Score: ${score}%"
 
 # confirm that the PLIST is well formed, if plutil is available (e.g. running on Darwin / OS X)
+test `which plutil` && plutil -lint -s "$PLIST"
+
+# generate a JSON equivalent to make reading easier
 test `which plutil` && plutil -convert json -e "json" "$PLIST"
 
 #

--- a/tests/bonjour-tests.sh
+++ b/tests/bonjour-tests.sh
@@ -37,7 +37,7 @@ else
 	IPPTOOL="ipptool"
 fi
 
-PLIST="$1 Bonjour Results.plist"
+PLIST="$1 Bonjour Results $(date +'%Y%m%d%H%M').plist"
 
 #
 # Figure out the proper echo options...
@@ -181,7 +181,7 @@ fi
 
 # B-2. IPP TXT keys test: The IPP TXT record contains all required keys.
 start_test "B-2. IPP TXT keys test"
-$IPPFIND "$1._ipp._tcp.local." --txt adminurl --txt pdl --txt rp --txt UUID --quiet
+$IPPFIND --name "$1" "_ipp._tcp.local." --txt adminurl --txt pdl --txt rp --txt UUID --quiet
 if test $? = 0; then
 	pass=`expr $pass + 1`
 	end_test PASS
@@ -192,32 +192,32 @@ fi
 
 # B-3. IPP Resolve test: Printer responds to an IPP Get-Printer-Attributes request using the resolved hostname, port, and resource path.
 start_test "B-3. IPP Resolve test"
-$IPPFIND "$1._ipp._tcp.local." --ls >/dev/null
+$IPPFIND --name "$1" "_ipp._tcp.local." --ls >/dev/null
 if test $? = 0; then
 	pass=`expr $pass + 1`
 	end_test PASS
 else
 	fail=`expr $fail + 1`
 	echo "<key>Errors</key><array>" >>"$PLIST"
-	$IPPFIND "$1._ipp._tcp.local." --ls | awk '{ print "<string>" $0 "</string>" }' >>"$PLIST"
+    $IPPFIND --name "$1" "_ipp._tcp.local." --ls | awk '{ print "<string>" $0 "</string>" }' >>"$PLIST"
 	echo "</array>" >>"$PLIST"
 	end_test FAIL
 fi
 
 # B-4. IPP TXT values test: The IPP TXT record values match the reported IPP attribute values.
 start_test "B-4. IPP TXT values test"
-$IPPFIND "$1._ipp._tcp.local." --txt-adminurl '^(http:|https:)//' --txt-pdl 'image/pwg-raster' --txt-pdl 'image/jpeg' --txt-rp '^ipp/(print|print/[^/]+)$' --txt-UUID '^[0-9a-fA-F]{8,8}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{12,12}$' -x $IPPTOOL -q '{}' bonjour-value-tests.test \;
+$IPPFIND --name "$1" "_ipp._tcp.local." --txt-adminurl '^(http:|https:)//' --txt-pdl 'image/pwg-raster' --txt-pdl 'image/jpeg' --txt-rp '^ipp/(print|print/[^/]+)$' --txt-UUID '^[0-9a-fA-F]{8,8}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{12,12}$' -x $IPPTOOL -q '{}' bonjour-value-tests.test \;
 if test $? = 0; then
 	pass=`expr $pass + 1`
 	end_test PASS
 else
 	fail=`expr $fail + 1`
-	$IPPFIND "$1._ipp._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail4 \;
+    $IPPFIND --name "$1" "_ipp._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail4 \;
 fi
 
 # B-5. TLS tests: Performed only if TLS is supported
 start_test "B-5. TLS tests"
-$IPPFIND "$1._ipp._tcp.local." --txt tls --quiet
+$IPPFIND --name "$1" "_ipp._tcp.local." --txt tls --quiet
 if test $? = 0; then
 	pass=`expr $pass + 1`
 	HAVE_TLS=1
@@ -231,7 +231,7 @@ fi
 # B-5.1 HTTP Upgrade test: Printer responds to an IPP Get-Printer-Attributes request after doing an HTTP Upgrade to TLS.
 start_test "B-5.1 HTTP Upgrade test"
 if test $HAVE_TLS = 1; then
-	error=`$IPPFIND "$1._ipp._tcp.local." -x $IPPTOOL -E -q '{}' bonjour-access-tests.test \; 2>&1`
+	error=`$IPPFIND --name "$1" "_ipp._tcp.local." -x $IPPTOOL -E -q '{}' bonjour-access-tests.test \; 2>&1`
 	if test $? = 0; then
 		pass=`expr $pass + 1`
 		end_test PASS
@@ -250,7 +250,7 @@ fi
 # B-5.2 IPPS Browse test: Printer appears in a search for "_ipps._tcp,_print" services.
 start_test "B-5.2 IPPS Browse test"
 if test $HAVE_TLS = 1; then
-	$IPPFIND _ipps._tcp,_print.local. --name "$1" --quiet
+	$IPPFIND "_ipps._tcp,_print.local." --name "$1" --quiet
 	if test $? = 0; then
 		pass=`expr $pass + 1`
 		end_test PASS
@@ -266,13 +266,13 @@ fi
 # B-5.3 IPPS TXT keys test: The TXT record for IPPS contains all required keys
 start_test "B-5.3 IPPS TXT keys test"
 if test $HAVE_TLS = 1; then
-	$IPPFIND "$1._ipps._tcp.local." --txt adminurl --txt pdl --txt rp --txt TLS --txt UUID --quiet
+    $IPPFIND --name "$1" "_ipps._tcp.local." --txt adminurl --txt pdl --txt rp --txt TLS --txt UUID --quiet
 	if test $? = 0; then
 		pass=`expr $pass + 1`
 		end_test PASS
 	else
 		fail=`expr $fail + 1`
-		$IPPFIND "$1._ipps._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail5.3 \;
+	    $IPPFIND --name "$1" "_ipps._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail5.3 \;
 	fi
 else
 	skip=`expr $skip + 1`
@@ -282,14 +282,14 @@ fi
 # B-5.4 IPPS Resolve test: Printer responds to an IPPS Get-Printer-Attributes request using the resolved hostname, port, and resource path.
 start_test "B-5.4 IPPS Resolve test"
 if test $HAVE_TLS = 1; then
-	$IPPFIND "$1._ipps._tcp.local." --ls >/dev/null
+    $IPPFIND --name "$1" "_ipps._tcp.local." --ls >/dev/null
 	if test $? = 0; then
 		pass=`expr $pass + 1`
 		end_test PASS
 	else
 		fail=`expr $fail + 1`
 		echo "<key>Errors</key><array>" >>"$PLIST"
-		$IPPFIND "$1._ipps._tcp.local." --ls | awk '{ print "<string>" $0 "</string>" }' >>"$PLIST"
+	    $IPPFIND --name "$1" "_ipps._tcp.local." --ls | awk '{ print "<string>" $0 "</string>" }' >>"$PLIST"
 		echo "</array>" >>"$PLIST"
 		end_test FAIL
 	fi
@@ -301,13 +301,13 @@ fi
 # B-5.5 IPPS TXT values test: The TXT record values for IPPS match the reported IPPS attribute values.
 start_test "B-5.5 IPPS TXT values test"
 if test $HAVE_TLS = 1; then
-	$IPPFIND "$1._ipps._tcp.local." --txt-adminurl '^(http:|https:)//' --txt-pdl 'image/pwg-raster' --txt-pdl 'image/jpeg' --txt-rp '^ipp/(print|print/[^/]+)$' --txt-UUID '^[0-9a-fA-F]{8,8}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{12,12}$' -x $IPPTOOL -q '{}' bonjour-value-tests.test \;
+    $IPPFIND --name "$1" "_ipps._tcp.local." --txt-adminurl '^(http:|https:)//' --txt-pdl 'image/pwg-raster' --txt-pdl 'image/jpeg' --txt-rp '^ipp/(print|print/[^/]+)$' --txt-UUID '^[0-9a-fA-F]{8,8}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{12,12}$' -x $IPPTOOL -q '{}' bonjour-value-tests.test \;
 	if test $? = 0; then
 		pass=`expr $pass + 1`
 		end_test PASS
 	else
 		fail=`expr $fail + 1`
-		$IPPFIND "$1._ipps._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail5.5 \;
+	    $IPPFIND --name "$1" "_ipps._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail5.5 \;
 	fi
 else
 	skip=`expr $skip + 1`
@@ -338,6 +338,9 @@ score=`expr $pass + $skip`
 score=`expr 100 \* $score / $total`
 echo "Summary: $total tests, $pass passed, $fail failed, $skip skipped"
 echo "Score: ${score}%"
+
+# confirm that the PLIST is well formed, if plutil is available (e.g. running on Darwin / OS X)
+test `which plutil` && plutil -convert json -e "json" "$PLIST"
 
 #
 # End of "$Id: bonjour-tests.sh 12897 2015-10-09 19:18:39Z msweet $".

--- a/tests/bonjour-tests.sh.in
+++ b/tests/bonjour-tests.sh.in
@@ -340,6 +340,9 @@ echo "Summary: $total tests, $pass passed, $fail failed, $skip skipped"
 echo "Score: ${score}%"
 
 # confirm that the PLIST is well formed, if plutil is available (e.g. running on Darwin / OS X)
+test `which plutil` && plutil -lint -s "$PLIST"
+
+# generate a JSON equivalent to make reading easier
 test `which plutil` && plutil -convert json -e "json" "$PLIST"
 
 #

--- a/tests/bonjour-tests.sh.in
+++ b/tests/bonjour-tests.sh.in
@@ -37,7 +37,7 @@ else
 	IPPTOOL="ipptool"
 fi
 
-PLIST="$1 Bonjour Results.plist"
+PLIST="$1 Bonjour Results $(date +'%Y%m%d%H%M').plist"
 
 #
 # Figure out the proper echo options...
@@ -181,7 +181,7 @@ fi
 
 # B-2. IPP TXT keys test: The IPP TXT record contains all required keys.
 start_test "B-2. IPP TXT keys test"
-$IPPFIND "$1._ipp._tcp.local." --txt adminurl --txt pdl --txt rp --txt UUID --quiet
+$IPPFIND --name "$1" "_ipp._tcp.local." --txt adminurl --txt pdl --txt rp --txt UUID --quiet
 if test $? = 0; then
 	pass=`expr $pass + 1`
 	end_test PASS
@@ -192,32 +192,32 @@ fi
 
 # B-3. IPP Resolve test: Printer responds to an IPP Get-Printer-Attributes request using the resolved hostname, port, and resource path.
 start_test "B-3. IPP Resolve test"
-$IPPFIND "$1._ipp._tcp.local." --ls >/dev/null
+$IPPFIND --name "$1" "_ipp._tcp.local." --ls >/dev/null
 if test $? = 0; then
 	pass=`expr $pass + 1`
 	end_test PASS
 else
 	fail=`expr $fail + 1`
 	echo "<key>Errors</key><array>" >>"$PLIST"
-	$IPPFIND "$1._ipp._tcp.local." --ls | awk '{ print "<string>" $0 "</string>" }' >>"$PLIST"
+    $IPPFIND --name "$1" "_ipp._tcp.local." --ls | awk '{ print "<string>" $0 "</string>" }' >>"$PLIST"
 	echo "</array>" >>"$PLIST"
 	end_test FAIL
 fi
 
 # B-4. IPP TXT values test: The IPP TXT record values match the reported IPP attribute values.
 start_test "B-4. IPP TXT values test"
-$IPPFIND "$1._ipp._tcp.local." --txt-adminurl '^(http:|https:)//' --txt-pdl 'image/pwg-raster' --txt-pdl 'image/jpeg' --txt-rp '^ipp/(print|print/[^/]+)$' --txt-UUID '^[0-9a-fA-F]{8,8}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{12,12}$' -x $IPPTOOL -q '{}' bonjour-value-tests.test \;
+$IPPFIND --name "$1" "_ipp._tcp.local." --txt-adminurl '^(http:|https:)//' --txt-pdl 'image/pwg-raster' --txt-pdl 'image/jpeg' --txt-rp '^ipp/(print|print/[^/]+)$' --txt-UUID '^[0-9a-fA-F]{8,8}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{12,12}$' -x $IPPTOOL -q '{}' bonjour-value-tests.test \;
 if test $? = 0; then
 	pass=`expr $pass + 1`
 	end_test PASS
 else
 	fail=`expr $fail + 1`
-	$IPPFIND "$1._ipp._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail4 \;
+    $IPPFIND --name "$1" "_ipp._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail4 \;
 fi
 
 # B-5. TLS tests: Performed only if TLS is supported
 start_test "B-5. TLS tests"
-$IPPFIND "$1._ipp._tcp.local." --txt tls --quiet
+$IPPFIND --name "$1" "_ipp._tcp.local." --txt tls --quiet
 if test $? = 0; then
 	pass=`expr $pass + 1`
 	HAVE_TLS=1
@@ -231,7 +231,7 @@ fi
 # B-5.1 HTTP Upgrade test: Printer responds to an IPP Get-Printer-Attributes request after doing an HTTP Upgrade to TLS.
 start_test "B-5.1 HTTP Upgrade test"
 if test $HAVE_TLS = 1; then
-	error=`$IPPFIND "$1._ipp._tcp.local." -x $IPPTOOL -E -q '{}' bonjour-access-tests.test \; 2>&1`
+	error=`$IPPFIND --name "$1" "_ipp._tcp.local." -x $IPPTOOL -E -q '{}' bonjour-access-tests.test \; 2>&1`
 	if test $? = 0; then
 		pass=`expr $pass + 1`
 		end_test PASS
@@ -250,7 +250,7 @@ fi
 # B-5.2 IPPS Browse test: Printer appears in a search for "_ipps._tcp,_print" services.
 start_test "B-5.2 IPPS Browse test"
 if test $HAVE_TLS = 1; then
-	$IPPFIND _ipps._tcp,_print.local. --name "$1" --quiet
+	$IPPFIND "_ipps._tcp,_print.local." --name "$1" --quiet
 	if test $? = 0; then
 		pass=`expr $pass + 1`
 		end_test PASS
@@ -266,13 +266,13 @@ fi
 # B-5.3 IPPS TXT keys test: The TXT record for IPPS contains all required keys
 start_test "B-5.3 IPPS TXT keys test"
 if test $HAVE_TLS = 1; then
-	$IPPFIND "$1._ipps._tcp.local." --txt adminurl --txt pdl --txt rp --txt TLS --txt UUID --quiet
+    $IPPFIND --name "$1" "_ipps._tcp.local." --txt adminurl --txt pdl --txt rp --txt TLS --txt UUID --quiet
 	if test $? = 0; then
 		pass=`expr $pass + 1`
 		end_test PASS
 	else
 		fail=`expr $fail + 1`
-		$IPPFIND "$1._ipps._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail5.3 \;
+	    $IPPFIND --name "$1" "_ipps._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail5.3 \;
 	fi
 else
 	skip=`expr $skip + 1`
@@ -282,14 +282,14 @@ fi
 # B-5.4 IPPS Resolve test: Printer responds to an IPPS Get-Printer-Attributes request using the resolved hostname, port, and resource path.
 start_test "B-5.4 IPPS Resolve test"
 if test $HAVE_TLS = 1; then
-	$IPPFIND "$1._ipps._tcp.local." --ls >/dev/null
+    $IPPFIND --name "$1" "_ipps._tcp.local." --ls >/dev/null
 	if test $? = 0; then
 		pass=`expr $pass + 1`
 		end_test PASS
 	else
 		fail=`expr $fail + 1`
 		echo "<key>Errors</key><array>" >>"$PLIST"
-		$IPPFIND "$1._ipps._tcp.local." --ls | awk '{ print "<string>" $0 "</string>" }' >>"$PLIST"
+	    $IPPFIND --name "$1" "_ipps._tcp.local." --ls | awk '{ print "<string>" $0 "</string>" }' >>"$PLIST"
 		echo "</array>" >>"$PLIST"
 		end_test FAIL
 	fi
@@ -301,13 +301,13 @@ fi
 # B-5.5 IPPS TXT values test: The TXT record values for IPPS match the reported IPPS attribute values.
 start_test "B-5.5 IPPS TXT values test"
 if test $HAVE_TLS = 1; then
-	$IPPFIND "$1._ipps._tcp.local." --txt-adminurl '^(http:|https:)//' --txt-pdl 'image/pwg-raster' --txt-pdl 'image/jpeg' --txt-rp '^ipp/(print|print/[^/]+)$' --txt-UUID '^[0-9a-fA-F]{8,8}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{12,12}$' -x $IPPTOOL -q '{}' bonjour-value-tests.test \;
+    $IPPFIND --name "$1" "_ipps._tcp.local." --txt-adminurl '^(http:|https:)//' --txt-pdl 'image/pwg-raster' --txt-pdl 'image/jpeg' --txt-rp '^ipp/(print|print/[^/]+)$' --txt-UUID '^[0-9a-fA-F]{8,8}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{4,4}-[0-9a-fA-F]{12,12}$' -x $IPPTOOL -q '{}' bonjour-value-tests.test \;
 	if test $? = 0; then
 		pass=`expr $pass + 1`
 		end_test PASS
 	else
 		fail=`expr $fail + 1`
-		$IPPFIND "$1._ipps._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail5.5 \;
+	    $IPPFIND --name "$1" "_ipps._tcp.local." -x ./bonjour-tests.sh '{service_name}' _fail5.5 \;
 	fi
 else
 	skip=`expr $skip + 1`
@@ -338,6 +338,9 @@ score=`expr $pass + $skip`
 score=`expr 100 \* $score / $total`
 echo "Summary: $total tests, $pass passed, $fail failed, $skip skipped"
 echo "Score: ${score}%"
+
+# confirm that the PLIST is well formed, if plutil is available (e.g. running on Darwin / OS X)
+test `which plutil` && plutil -convert json -e "json" "$PLIST"
 
 #
 # End of "$Id: bonjour-tests.sh 12897 2015-10-09 19:18:39Z msweet $".

--- a/tests/document-tests.sh
+++ b/tests/document-tests.sh
@@ -54,7 +54,7 @@ if test "`ls -d pwg-raster-samples-*dpi-20150616 2>/dev/null`" = ""; then
 	exit 1
 fi
 
-$IPPFIND "$1._ipp._tcp.local." -x $IPPTOOL -P "$1 Document Results.plist" -I '{}' document-tests.test \;
+$IPPFIND --name "$1" "_ipp._tcp.local." -x $IPPTOOL -P "$1 Document Results $(date +'%Y%m%d%H%M').plist" -I '{}' document-tests.test \;
 
 #
 # End of "$Id: document-tests.sh 12897 2015-10-09 19:18:39Z msweet $".

--- a/tests/document-tests.sh
+++ b/tests/document-tests.sh
@@ -54,7 +54,12 @@ if test "`ls -d pwg-raster-samples-*dpi-20150616 2>/dev/null`" = ""; then
 	exit 1
 fi
 
-$IPPFIND --name "$1" "_ipp._tcp.local." -x $IPPTOOL -P "$1 Document Results $(date +'%Y%m%d%H%M').plist" -I '{}' document-tests.test \;
+
+PLIST="$1 Document Results $(date +'%Y%m%d%H%M').plist"
+$IPPFIND --name "$1" "_ipp._tcp.local." -x $IPPTOOL -P "$PLIST" -I '{}' document-tests.test \;
+
+# confirm that the PLIST is well formed, if plutil is available (e.g. running on Darwin / OS X)
+test `which plutil` && plutil -lint -s "${PLIST}"
 
 #
 # End of "$Id: document-tests.sh 12897 2015-10-09 19:18:39Z msweet $".

--- a/tests/document-tests.sh.in
+++ b/tests/document-tests.sh.in
@@ -54,7 +54,7 @@ if test "`ls -d pwg-raster-samples-*dpi-@PWGRASTER_VERSION@ 2>/dev/null`" = ""; 
 	exit 1
 fi
 
-$IPPFIND "$1._ipp._tcp.local." -x $IPPTOOL -P "$1 Document Results.plist" -I '{}' document-tests.test \;
+$IPPFIND --name "$1" "_ipp._tcp.local." -x $IPPTOOL -P "$1 Document Results $(date +'%Y%m%d%H%M').plist" -I '{}' document-tests.test \;
 
 #
 # End of "$Id: document-tests.sh 12897 2015-10-09 19:18:39Z msweet $".

--- a/tests/document-tests.sh.in
+++ b/tests/document-tests.sh.in
@@ -54,7 +54,12 @@ if test "`ls -d pwg-raster-samples-*dpi-@PWGRASTER_VERSION@ 2>/dev/null`" = ""; 
 	exit 1
 fi
 
-$IPPFIND --name "$1" "_ipp._tcp.local." -x $IPPTOOL -P "$1 Document Results $(date +'%Y%m%d%H%M').plist" -I '{}' document-tests.test \;
+
+PLIST="$1 Document Results $(date +'%Y%m%d%H%M').plist"
+$IPPFIND --name "$1" "_ipp._tcp.local." -x $IPPTOOL -P "$PLIST" -I '{}' document-tests.test \;
+
+# confirm that the PLIST is well formed, if plutil is available (e.g. running on Darwin / OS X)
+test `which plutil` && plutil -lint -s "${PLIST}"
 
 #
 # End of "$Id: document-tests.sh 12897 2015-10-09 19:18:39Z msweet $".

--- a/tests/ipp-tests.sh
+++ b/tests/ipp-tests.sh
@@ -47,7 +47,7 @@ PLIST="$1 IPP Results $(date +'%Y%m%d%H%M').plist"
 ${IPPFIND} --name "^${1}\$" "_ipp._tcp.local." -x "${IPPTOOL}" -P "${PLIST}" -I '{}' ipp-tests.test \;
 
 # confirm that the PLIST is well formed, if plutil is available (e.g. running on Darwin / OS X)
-test `which plutil` && plutil -convert json -e "json" "${PLIST}"
+test `which plutil` && plutil -lint -s "${PLIST}"
 
 
 #

--- a/tests/ipp-tests.sh
+++ b/tests/ipp-tests.sh
@@ -43,7 +43,12 @@ for file in color.jpg; do
 	fi
 done
 
-$IPPFIND "$1._ipp._tcp.local." -x $IPPTOOL -P "$1 IPP Results.plist" -I '{}' ipp-tests.test \;
+PLIST="$1 IPP Results $(date +'%Y%m%d%H%M').plist"
+${IPPFIND} --name "^${1}\$" "_ipp._tcp.local." -x "${IPPTOOL}" -P "${PLIST}" -I '{}' ipp-tests.test \;
+
+# confirm that the PLIST is well formed, if plutil is available (e.g. running on Darwin / OS X)
+test `which plutil` && plutil -convert json -e "json" "${PLIST}"
+
 
 #
 # End of "$Id: ipp-tests.sh 12897 2015-10-09 19:18:39Z msweet $".

--- a/tests/ipp-tests.sh.in
+++ b/tests/ipp-tests.sh.in
@@ -47,7 +47,7 @@ PLIST="$1 IPP Results $(date +'%Y%m%d%H%M').plist"
 ${IPPFIND} --name "^${1}\$" "_ipp._tcp.local." -x "${IPPTOOL}" -P "${PLIST}" -I '{}' ipp-tests.test \;
 
 # confirm that the PLIST is well formed, if plutil is available (e.g. running on Darwin / OS X)
-test `which plutil` && plutil -convert json -e "json" "${PLIST}"
+test `which plutil` && plutil -lint -s "${PLIST}"
 
 
 #

--- a/tests/ipp-tests.sh.in
+++ b/tests/ipp-tests.sh.in
@@ -43,7 +43,12 @@ for file in color.jpg; do
 	fi
 done
 
-$IPPFIND "$1._ipp._tcp.local." -x $IPPTOOL -P "$1 IPP Results.plist" -I '{}' ipp-tests.test \;
+PLIST="$1 IPP Results $(date +'%Y%m%d%H%M').plist"
+${IPPFIND} --name "^${1}\$" "_ipp._tcp.local." -x "${IPPTOOL}" -P "${PLIST}" -I '{}' ipp-tests.test \;
+
+# confirm that the PLIST is well formed, if plutil is available (e.g. running on Darwin / OS X)
+test `which plutil` && plutil -convert json -e "json" "${PLIST}"
+
 
 #
 # End of "$Id: ipp-tests.sh 12897 2015-10-09 19:18:39Z msweet $".

--- a/tests/ipp-tests.test
+++ b/tests/ipp-tests.test
@@ -168,7 +168,7 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 #
 # Required by: PWG 5100.14 Section 5.x
 {
-	NAME "I-9. Get-Printer-Attributes Operation (default)"
+	NAME "I-9. Get-Printer-Attributes Operation (IPP Everywhere Baseline)"
 	OPERATION Get-Printer-Attributes
 	GROUP operation-attributes-tag
 	ATTR charset attributes-charset utf-8
@@ -178,18 +178,31 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 
 	STATUS successful-ok
 
+    # Conditional requirement indicator detection
+	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "deflate" DEFINE-MATCH HAVE_DEFLATE
+	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "gzip" DEFINE-MATCH HAVE_GZIP
+	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE "application/pdf" DEFINE-MATCH HAVE_PDF
+	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE "application/openxps" DEFINE-MATCH HAVE_OPENXPS
+	EXPECT feed-orientation-supported OF-TYPE keyword IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_FEED_ORIENTATION
+	EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3 DEFINE-MATCH HAVE_FINISHINGS
+	EXPECT ipp-versions-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "2.1" DEFINE-MATCH HAVE_IPP_2_1
+	EXPECT ipp-versions-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "2.2" DEFINE-MATCH HAVE_IPP_2_2
+    EXPECT multiple-document-jobs-supported OF-TYPE boolean IN-GROUP printer-attributes-tag WITH-VALUE true DEFINE-MATCH HAVE_MULTIPLE_DOCUMENT_JOBS
+    
+
 	# PWG 5100.14 - Table 5 - Operations
 	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0002 # Print-Job
-	EXPECT operations-supported WITH-VALUE 0x0004 # Validate-Job
-	EXPECT operations-supported WITH-VALUE 0x0005 # Create-Job
-	EXPECT operations-supported WITH-VALUE 0x0006 # Send-Document
-	EXPECT operations-supported WITH-VALUE 0x0008 # Cancel-Job
-	EXPECT operations-supported WITH-VALUE 0x0009 # Get-Job-Attributes
-	EXPECT operations-supported WITH-VALUE 0x000a # Get-Jobs
-	EXPECT operations-supported WITH-VALUE 0x000b # Get-Printer-Attributes
-	EXPECT operations-supported WITH-VALUE 0x0039 # Cancel-My-Jobs
-	EXPECT operations-supported WITH-VALUE 0x003b # Close-Job
-	EXPECT operations-supported WITH-VALUE 0x003c # Identify-Printer
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0004  # Validate-Job
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0005  # Create-Job
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0006  # Send-Document
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0008  # Cancel-Job
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0009  # Get-Job-Attributes
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x000a  # Get-Jobs
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x000b  # Get-Printer-Attributes
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0039  # Cancel-My-Jobs
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x003b  # Close-Job
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x003c  # Identify-Printer
+
 
 	# PWG 5100.14 - Table 6 - Printer Description Attributes
 	EXPECT charset-configured OF-TYPE charset IN-GROUP printer-attributes-tag COUNT 1
@@ -200,8 +213,6 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 	EXPECT color-supported WITH-VALUE true DEFINE-MATCH HAVE_COLOR
 
 	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "none"
-	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "deflate" DEFINE-MATCH HAVE_DEFLATE
-	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "gzip" DEFINE-MATCH HAVE_GZIP
 
 	EXPECT copies-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0
 	EXPECT copies-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag
@@ -209,15 +220,12 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 	EXPECT document-format-default OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag COUNT 1
 	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE "image/jpeg"
 	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE "image/pwg-raster"
-	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE "application/pdf" DEFINE-MATCH HAVE_PDF
 
 	EXPECT document-password-supported OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 IF-DEFINED HAVE_PDF
 
-	EXPECT feed-orientation-supported OF-TYPE keyword IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_FEED_ORIENTATION
 	EXPECT feed-orientation-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 IF-DEFINED HAVE_FEED_ORIENTATION
 
-	EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3 DEFINE-MATCH HAVE_FINISHINGS
-	EXPECT finishings-default OF-TYPE enum IN-GROUP printer-attributes-tag IF-DEFINED HAVE_FINISHINGS
+	EXPECT finishings-default OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE-FROM finishings-supported IF-DEFINED HAVE_FINISHINGS
 
 	EXPECT generated-natural-language-supported OF-TYPE naturalLanguage IN-GROUP printer-attributes-tag
 
@@ -310,17 +318,15 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 
 	# operations-supported tested above for required operations
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT orientation-requested-default OF-TYPE no-value|enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 3,4,5,6,7
 	EXPECT orientation-requested-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3,4,5,6,7
+	EXPECT orientation-requested-default OF-TYPE no-value|enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM orientation-requested-supported
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT output-bin-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag COUNT 1
-	EXPECT output-bin-default DEFINE-VALUE DEFAULT_OUTPUT_BIN
 	EXPECT output-bin-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag
+	EXPECT output-bin-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM output-bin-supported
+	EXPECT output-bin-default DEFINE-VALUE DEFAULT_OUTPUT_BIN
 
-	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "document-number" IF-DEFINED HAVE_PDF
-	EXPECT overrides-supported WITH-VALUE "pages" IF-DEFINED HAVE_PDF
+	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "document-number" IF-DEFINED HAVE_MULTIPLE_DOCUMENT_JOBS
+	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "pages" IF-DEFINED HAVE_PDF
 
 	EXPECT page-ranges-supported OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE true IF-DEFINED HAVE_PDF
 
@@ -329,25 +335,21 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 	EXPECT pages-per-minute-color OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 IF-DEFINED HAVE_COLOR
 	EXPECT !pages-per-minute-color IF-NOT-DEFINED HAVE_COLOR
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT print-color-mode-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^(auto|auto-monochrome|bi-level|color|highlight|monochrome|process-bi-level|process-monochrome)$/"
-	EXPECT print-color-mode-default DEFINE-VALUE DEFAULT_PRINT_COLOR_MODE
 	EXPECT print-color-mode-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-ALL-VALUES "/^(auto|auto-monochrome|bi-level|color|highlight|monochrome|process-bi-level|process-monochrome)$/"
+	EXPECT print-color-mode-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM print-color-mode-supported
+	EXPECT print-color-mode-default DEFINE-VALUE DEFAULT_PRINT_COLOR_MODE
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT print-content-optimize-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^(auto|graphic|photo|text|text-and-graphic)$/"
-	EXPECT print-content-optimize-default DEFINE-VALUE DEFAULT_PRINT_CONTENT_OPTIMIZE
 	EXPECT print-content-optimize-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-ALL-VALUES "/^(auto|graphic|photo|text|text-and-graphic)$/"
+	EXPECT print-content-optimize-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM print-content-optimize-supported
+	EXPECT print-content-optimize-default DEFINE-VALUE DEFAULT_PRINT_CONTENT_OPTIMIZE
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT print-rendering-intent-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^(auto|absolute|perceptual|relative|relative-bpc|saturation)$/"
-	EXPECT print-rendering-intent-default DEFINE-VALUE DEFAULT_PRINT_RENDERING_INTENT
 	EXPECT print-rendering-intent-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-ALL-VALUES "/^(auto|absolute|perceptual|relative|relative-bpc|saturation)$/"
+	EXPECT print-rendering-intent-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM print-rendering-intent-supported
+	EXPECT print-rendering-intent-default DEFINE-VALUE DEFAULT_PRINT_RENDERING_INTENT
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT print-quality-default OF-TYPE enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 3,4,5
-	EXPECT print-quality-default DEFINE-VALUE DEFAULT_PRINT_QUALITY
 	EXPECT print-quality-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3,4,5
+	EXPECT print-quality-default OF-TYPE enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM print-quality-supported
+	EXPECT print-quality-default DEFINE-VALUE DEFAULT_PRINT_QUALITY
 
 	EXPECT ?printer-alert OF-TYPE octetString IN-GROUP printer-attributes-tag WITH-ALL-VALUES "$ALERT_REGEX"
 	EXPECT ?printer-alert-description OF-TYPE text IN-GROUP printer-attributes-tag SAME-COUNT-AS printer-alert
@@ -391,10 +393,9 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 
 	EXPECT printer-organizational-unit OF-TYPE text IN-GROUP printer-attributes-tag
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT printer-resolution-default OF-TYPE resolution IN-GROUP printer-attributes-tag COUNT 1
-	EXPECT printer-resolution-default DEFINE-VALUE DEFAULT_PRINTER_RESOLUTION
 	EXPECT printer-resolution-supported OF-TYPE resolution IN-GROUP printer-attributes-tag
+	EXPECT printer-resolution-default OF-TYPE resolution IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM printer-resolution-supported
+	EXPECT printer-resolution-default DEFINE-VALUE DEFAULT_PRINTER_RESOLUTION
 
 	EXPECT printer-state OF-TYPE enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 3,4,5
 
@@ -429,10 +430,9 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 
 	EXPECT queued-job-count OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT sides-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-ALL-VALUES "/^(one-sided|two-sided-long-edge|two-sided-short-edge)$$/"
-	EXPECT sides-default DEFINE-VALUE DEFAULT_SIDES
 	EXPECT sides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-ALL-VALUES "/^(one-sided|two-sided-long-edge|two-sided-short-edge)$$/"
+	EXPECT sides-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM sides-supported
+	EXPECT sides-default DEFINE-VALUE DEFAULT_SIDES
 
 	EXPECT uri-authentication-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
 

--- a/tests/ipp-tests.test.in
+++ b/tests/ipp-tests.test.in
@@ -168,7 +168,7 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 #
 # Required by: PWG 5100.14 Section 5.x
 {
-	NAME "I-9. Get-Printer-Attributes Operation (default)"
+	NAME "I-9. Get-Printer-Attributes Operation (IPP Everywhere Baseline)"
 	OPERATION Get-Printer-Attributes
 	GROUP operation-attributes-tag
 	ATTR charset attributes-charset utf-8
@@ -178,18 +178,31 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 
 	STATUS successful-ok
 
+    # Conditional requirement indicator detection
+	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "deflate" DEFINE-MATCH HAVE_DEFLATE
+	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "gzip" DEFINE-MATCH HAVE_GZIP
+	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE "application/pdf" DEFINE-MATCH HAVE_PDF
+	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE "application/openxps" DEFINE-MATCH HAVE_OPENXPS
+	EXPECT feed-orientation-supported OF-TYPE keyword IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_FEED_ORIENTATION
+	EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3 DEFINE-MATCH HAVE_FINISHINGS
+	EXPECT ipp-versions-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "2.1" DEFINE-MATCH HAVE_IPP_2_1
+	EXPECT ipp-versions-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "2.2" DEFINE-MATCH HAVE_IPP_2_2
+    EXPECT multiple-document-jobs-supported OF-TYPE boolean IN-GROUP printer-attributes-tag WITH-VALUE true DEFINE-MATCH HAVE_MULTIPLE_DOCUMENT_JOBS
+    
+
 	# PWG 5100.14 - Table 5 - Operations
 	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0002 # Print-Job
-	EXPECT operations-supported WITH-VALUE 0x0004 # Validate-Job
-	EXPECT operations-supported WITH-VALUE 0x0005 # Create-Job
-	EXPECT operations-supported WITH-VALUE 0x0006 # Send-Document
-	EXPECT operations-supported WITH-VALUE 0x0008 # Cancel-Job
-	EXPECT operations-supported WITH-VALUE 0x0009 # Get-Job-Attributes
-	EXPECT operations-supported WITH-VALUE 0x000a # Get-Jobs
-	EXPECT operations-supported WITH-VALUE 0x000b # Get-Printer-Attributes
-	EXPECT operations-supported WITH-VALUE 0x0039 # Cancel-My-Jobs
-	EXPECT operations-supported WITH-VALUE 0x003b # Close-Job
-	EXPECT operations-supported WITH-VALUE 0x003c # Identify-Printer
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0004  # Validate-Job
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0005  # Create-Job
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0006  # Send-Document
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0008  # Cancel-Job
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0009  # Get-Job-Attributes
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x000a  # Get-Jobs
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x000b  # Get-Printer-Attributes
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x0039  # Cancel-My-Jobs
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x003b  # Close-Job
+	EXPECT operations-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 0x003c  # Identify-Printer
+
 
 	# PWG 5100.14 - Table 6 - Printer Description Attributes
 	EXPECT charset-configured OF-TYPE charset IN-GROUP printer-attributes-tag COUNT 1
@@ -200,8 +213,6 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 	EXPECT color-supported WITH-VALUE true DEFINE-MATCH HAVE_COLOR
 
 	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "none"
-	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "deflate" DEFINE-MATCH HAVE_DEFLATE
-	EXPECT compression-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "gzip" DEFINE-MATCH HAVE_GZIP
 
 	EXPECT copies-default OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE >0
 	EXPECT copies-supported OF-TYPE rangeOfInteger IN-GROUP printer-attributes-tag
@@ -209,15 +220,12 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 	EXPECT document-format-default OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag COUNT 1
 	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE "image/jpeg"
 	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE "image/pwg-raster"
-	EXPECT document-format-supported OF-TYPE mimeMediaType IN-GROUP printer-attributes-tag WITH-VALUE "application/pdf" DEFINE-MATCH HAVE_PDF
 
 	EXPECT document-password-supported OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 IF-DEFINED HAVE_PDF
 
-	EXPECT feed-orientation-supported OF-TYPE keyword IN-GROUP printer-attributes-tag DEFINE-MATCH HAVE_FEED_ORIENTATION
 	EXPECT feed-orientation-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 IF-DEFINED HAVE_FEED_ORIENTATION
 
-	EXPECT finishings-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3 DEFINE-MATCH HAVE_FINISHINGS
-	EXPECT finishings-default OF-TYPE enum IN-GROUP printer-attributes-tag IF-DEFINED HAVE_FINISHINGS
+	EXPECT finishings-default OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE-FROM finishings-supported IF-DEFINED HAVE_FINISHINGS
 
 	EXPECT generated-natural-language-supported OF-TYPE naturalLanguage IN-GROUP printer-attributes-tag
 
@@ -310,17 +318,15 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 
 	# operations-supported tested above for required operations
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT orientation-requested-default OF-TYPE no-value|enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 3,4,5,6,7
 	EXPECT orientation-requested-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3,4,5,6,7
+	EXPECT orientation-requested-default OF-TYPE no-value|enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM orientation-requested-supported
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT output-bin-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag COUNT 1
-	EXPECT output-bin-default DEFINE-VALUE DEFAULT_OUTPUT_BIN
 	EXPECT output-bin-supported OF-TYPE keyword|name IN-GROUP printer-attributes-tag
+	EXPECT output-bin-default OF-TYPE keyword|name IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM output-bin-supported
+	EXPECT output-bin-default DEFINE-VALUE DEFAULT_OUTPUT_BIN
 
-	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "document-number" IF-DEFINED HAVE_PDF
-	EXPECT overrides-supported WITH-VALUE "pages" IF-DEFINED HAVE_PDF
+	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "document-number" IF-DEFINED HAVE_MULTIPLE_DOCUMENT_JOBS
+	EXPECT overrides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "pages" IF-DEFINED HAVE_PDF
 
 	EXPECT page-ranges-supported OF-TYPE boolean IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE true IF-DEFINED HAVE_PDF
 
@@ -329,25 +335,21 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 	EXPECT pages-per-minute-color OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1 IF-DEFINED HAVE_COLOR
 	EXPECT !pages-per-minute-color IF-NOT-DEFINED HAVE_COLOR
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT print-color-mode-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^(auto|auto-monochrome|bi-level|color|highlight|monochrome|process-bi-level|process-monochrome)$/"
-	EXPECT print-color-mode-default DEFINE-VALUE DEFAULT_PRINT_COLOR_MODE
 	EXPECT print-color-mode-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-ALL-VALUES "/^(auto|auto-monochrome|bi-level|color|highlight|monochrome|process-bi-level|process-monochrome)$/"
+	EXPECT print-color-mode-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM print-color-mode-supported
+	EXPECT print-color-mode-default DEFINE-VALUE DEFAULT_PRINT_COLOR_MODE
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT print-content-optimize-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^(auto|graphic|photo|text|text-and-graphic)$/"
-	EXPECT print-content-optimize-default DEFINE-VALUE DEFAULT_PRINT_CONTENT_OPTIMIZE
 	EXPECT print-content-optimize-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-ALL-VALUES "/^(auto|graphic|photo|text|text-and-graphic)$/"
+	EXPECT print-content-optimize-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM print-content-optimize-supported
+	EXPECT print-content-optimize-default DEFINE-VALUE DEFAULT_PRINT_CONTENT_OPTIMIZE
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT print-rendering-intent-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE "/^(auto|absolute|perceptual|relative|relative-bpc|saturation)$/"
-	EXPECT print-rendering-intent-default DEFINE-VALUE DEFAULT_PRINT_RENDERING_INTENT
 	EXPECT print-rendering-intent-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-ALL-VALUES "/^(auto|absolute|perceptual|relative|relative-bpc|saturation)$/"
+	EXPECT print-rendering-intent-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM print-rendering-intent-supported
+	EXPECT print-rendering-intent-default DEFINE-VALUE DEFAULT_PRINT_RENDERING_INTENT
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT print-quality-default OF-TYPE enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 3,4,5
-	EXPECT print-quality-default DEFINE-VALUE DEFAULT_PRINT_QUALITY
 	EXPECT print-quality-supported OF-TYPE enum IN-GROUP printer-attributes-tag WITH-VALUE 3,4,5
+	EXPECT print-quality-default OF-TYPE enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM print-quality-supported
+	EXPECT print-quality-default DEFINE-VALUE DEFAULT_PRINT_QUALITY
 
 	EXPECT ?printer-alert OF-TYPE octetString IN-GROUP printer-attributes-tag WITH-ALL-VALUES "$ALERT_REGEX"
 	EXPECT ?printer-alert-description OF-TYPE text IN-GROUP printer-attributes-tag SAME-COUNT-AS printer-alert
@@ -391,10 +393,9 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 
 	EXPECT printer-organizational-unit OF-TYPE text IN-GROUP printer-attributes-tag
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT printer-resolution-default OF-TYPE resolution IN-GROUP printer-attributes-tag COUNT 1
-	EXPECT printer-resolution-default DEFINE-VALUE DEFAULT_PRINTER_RESOLUTION
 	EXPECT printer-resolution-supported OF-TYPE resolution IN-GROUP printer-attributes-tag
+	EXPECT printer-resolution-default OF-TYPE resolution IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM printer-resolution-supported
+	EXPECT printer-resolution-default DEFINE-VALUE DEFAULT_PRINTER_RESOLUTION
 
 	EXPECT printer-state OF-TYPE enum IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE 3,4,5
 
@@ -429,10 +430,9 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+|(maxcapacity\=([0-9]|\-){0,1})(level\=([
 
 	EXPECT queued-job-count OF-TYPE integer IN-GROUP printer-attributes-tag COUNT 1
 
-	# TODO: Use WITH-VALUE-FROM "name-supported" syntax (STR #4470)
-	EXPECT sides-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-ALL-VALUES "/^(one-sided|two-sided-long-edge|two-sided-short-edge)$$/"
-	EXPECT sides-default DEFINE-VALUE DEFAULT_SIDES
 	EXPECT sides-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-ALL-VALUES "/^(one-sided|two-sided-long-edge|two-sided-short-edge)$$/"
+	EXPECT sides-default OF-TYPE keyword IN-GROUP printer-attributes-tag COUNT 1 WITH-VALUE-FROM sides-supported
+	EXPECT sides-default DEFINE-VALUE DEFAULT_SIDES
 
 	EXPECT uri-authentication-supported OF-TYPE keyword IN-GROUP printer-attributes-tag
 

--- a/tools/ipptool.c
+++ b/tools/ipptool.c
@@ -5803,7 +5803,7 @@ with_value(FILE            *outfile,	/* I - Output file */
     case IPP_TAG_BOOLEAN :
 	for (i = 0; i < attr->num_values; i ++)
 	{
-          if (!strcmp(value, "true") == attr->values[i].boolean)
+        if ( (!strcmp(value, "true") ) == attr->values[i].boolean)
           {
             if (!matchbuf[0])
 	      strlcpy(matchbuf, value, matchlen);


### PR DESCRIPTION
…a number of tests; centralized the DEFINE-MATCH expects in the top, and made 'document-number' keyword for "overrides-supported" be conditionally required depending on whether the Printer provides "multiple-document-jobs-supported" = 'true'