### PR TITLE
Resolution for Issue #48

### DIFF
--- a/tests/ipp-tests.test
+++ b/tests/ipp-tests.test
@@ -159,22 +159,56 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+;|maxcapacity\=-{0,1}[0-9]+;|level\=-{0,1
 }
 
 
-# Test Identify-Printer operation
+#
+# Check for Identify-Printer support
+#
+{
+	NAME "I-9.1 Get-Printer-Attributes (check for Identify-Printer support)"
+
+	OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR keyword requested-attributes "operations-supported","identify-actions-supported","identify-actions-default"
+
+	STATUS successful-ok
+
+	# 'media-col-database' attribute should never be returned unless
+	# explicitly requested...
+	EXPECT !media-col-database
+	EXPECT operations-supported WITH-VALUE 0x003c # Identify-Printer
+		IF-NOT-DEFINED IPP_EVERYWHERE_SERVER DEFINE-MATCH HAVE_IDENTIFY_PRINTER
+        
+	EXPECT identify-actions-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "/^(display|flash|sound|speak)$/" IF-DEFINED HAVE_IDENTIFY_PRINTER
+	EXPECT identify-actions-default OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE-FROM identify-actions-supported IF-DEFINED HAVE_IDENTIFY_PRINTER
+	EXPECT identify-actions-default OF-TYPE keyword IN-GROUP printer-attributes-tag DEFINE-VALUE IDENTIFY_ACTION_DEFAULT IF-DEFINED HAVE_IDENTIFY_PRINTER
+
+
+}
+
+
+#
+# Test Identify-Printer operation if supported
 #
 # Required by: PWG 5100.14 Section 5.x
 {
 	SKIP-IF-NOT-DEFINED HAVE_IDENTIFY_PRINTER
 
-	NAME "I-9. Identify-Printer Operation"
+	NAME "I-9.2 Identify-Printer (identify-action $IDENTIFY_ACTION_DEFAULT)"
 	OPERATION Identify-Printer
 	GROUP operation-attributes-tag
 	ATTR charset attributes-charset utf-8
 	ATTR naturalLanguage attributes-natural-language en
 	ATTR uri printer-uri $uri
 	ATTR name requesting-user-name $user
+    ATTR keyword identify-actions $IDENTIFY_ACTION_DEFAULT
+    ATTR text message "ipp-tests.test: $user testing Identify Printer"
 
 	STATUS successful-ok
 }
+
 
 
 # Test Get-Printer-Attributes operation

--- a/tests/ipp-tests.test.in
+++ b/tests/ipp-tests.test.in
@@ -159,22 +159,52 @@ DEFINE SUPPLY_REGEX "/^(type\=[A-Za-z]+;|maxcapacity\=-{0,1}[0-9]+;|level\=-{0,1
 }
 
 
-# Test Identify-Printer operation
+#
+# Check for Identify-Printer support
+#
+# Required by: PWG 5100.14 Section 5.x
+{
+	NAME "I-9.1 Get-Printer-Attributes (check for Identify-Printer support)"
+
+	OPERATION Get-Printer-Attributes
+
+	GROUP operation-attributes-tag
+	ATTR charset attributes-charset utf-8
+	ATTR language attributes-natural-language en
+	ATTR uri printer-uri $uri
+	ATTR keyword requested-attributes 'operations-supported','identify-actions-supported','identify-actions-default'
+
+	STATUS successful-ok
+
+	EXPECT operations-supported WITH-VALUE 0x003c # Identify-Printer
+		IF-NOT-DEFINED IPP_EVERYWHERE_SERVER DEFINE-MATCH HAVE_IDENTIFY_PRINTER
+        
+	EXPECT identify-actions-supported OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE "/^(display|flash|sound|speak)$/" IF-DEFINED HAVE_IDENTIFY_PRINTER
+	EXPECT identify-actions-default OF-TYPE keyword IN-GROUP printer-attributes-tag WITH-VALUE-FROM identify-actions-supported IF-DEFINED HAVE_IDENTIFY_PRINTER
+	EXPECT identify-actions-default OF-TYPE keyword IN-GROUP printer-attributes-tag DEFINE-VALUE IDENTIFY_ACTION_DEFAULT IF-DEFINED HAVE_IDENTIFY_PRINTER
+}
+
+
+#
+# Test Identify-Printer operation if supported
 #
 # Required by: PWG 5100.14 Section 5.x
 {
 	SKIP-IF-NOT-DEFINED HAVE_IDENTIFY_PRINTER
 
-	NAME "I-9. Identify-Printer Operation"
+	NAME "I-9.2 Identify-Printer (identify-action $IDENTIFY_ACTION_DEFAULT)"
 	OPERATION Identify-Printer
 	GROUP operation-attributes-tag
 	ATTR charset attributes-charset utf-8
 	ATTR naturalLanguage attributes-natural-language en
 	ATTR uri printer-uri $uri
 	ATTR name requesting-user-name $user
+    ATTR keyword identify-actions $IDENTIFY_ACTION_DEFAULT
+    ATTR text message "ipp-tests.test: $user testing Identify Printer"
 
 	STATUS successful-ok
 }
+
 
 
 # Test Get-Printer-Attributes operation


### PR DESCRIPTION
Added a new Test I-9.1 that does a Get-Printer-Attributes to check for Identify-Printer operation support and dependencies, and changed the existing I-9 to be I-9.2, with additional operation attributes "identify-actions" and "message".